### PR TITLE
Fixed string vars being tuples

### DIFF
--- a/bin/examine.py
+++ b/bin/examine.py
@@ -38,8 +38,8 @@ def main(argv):
 
     env_name = names[0]
     core_dir = abspath(join(dirname(__file__), '..'))
-    envs_dir = 'mae_envs/envs',
-    xmls_dir = 'xmls',
+    envs_dir = 'mae_envs/envs'
+    xmls_dir = 'xmls'
 
     if len(names) == 1:  # examine the environment
         examine_env(env_name, kwargs,


### PR DESCRIPTION
This pull request addresses issue #19 .
String vars with a trailing comma are interpreted as tuples. Removing the commas fixes the problems.